### PR TITLE
 Refine return types for all methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,8 +218,7 @@ impl Beanstalkd {
                 delay,
                 ttr,
                 data,
-            })
-            .and_then(|conn| handle_response!(conn))
+            }).and_then(|conn| handle_response!(conn))
     }
 
     /// Reserve a job to process.
@@ -439,13 +438,11 @@ mod tests {
                     .and_then(|(bean, _)| {
                         // how about another one?
                         bean.put(0, 1, 100, &b"more data"[..])
-                    })
-                    .inspect(|(_, response)| assert!(response.is_ok()))
+                    }).inspect(|(_, response)| assert!(response.is_ok()))
                     .and_then(|(bean, _)| {
                         // Let's watch a particular tube
                         bean.using("test")
-                    })
-                    .inspect(|(_, response)| match response {
+                    }).inspect(|(_, response)| match response {
                         Ok(v) => assert_eq!(*v, Response::Using("test".to_string())),
                         Err(e) => panic!("Unexpected error: {}", e),
                     })
@@ -472,63 +469,51 @@ mod tests {
                             assert_eq!(j.data, b"data");
                         }
                         _ => panic!("Wrong response received"),
-                    })
-                    .and_then(|(bean, response)| match response {
+                    }).and_then(|(bean, response)| match response {
                         Ok(Response::Reserved(j)) => bean.touch(j.id),
                         Ok(_) => panic!("Wrong response returned"),
                         Err(e) => panic!("Got error: {}", e),
-                    })
-                    .inspect(|(_, response)| match response {
+                    }).inspect(|(_, response)| match response {
                         Ok(v) => assert_eq!(*v, Response::Touched),
                         Err(e) => panic!("Got error: {}", e),
-                    })
-                    .and_then(|(bean, _)| {
+                    }).and_then(|(bean, _)| {
                         // how about another one?
                         bean.put(0, 1, 100, &b"more data"[..])
-                    })
-                    .and_then(|(bean, _)| bean.reserve())
+                    }).and_then(|(bean, _)| bean.reserve())
                     .and_then(|(bean, response)| match response {
                         Ok(Response::Reserved(job)) => bean.release(job.id, 10, 10),
                         Ok(_) => panic!("Wrong response returned"),
                         Err(e) => panic!("Got error: {}", e),
-                    })
-                    .inspect(|(_, response)| match response {
+                    }).inspect(|(_, response)| match response {
                         Ok(v) => assert_eq!(*v, Response::Released),
                         Err(e) => panic!("Got error: {}", e),
-                    })
-                    .and_then(|(bean, _)| bean.reserve())
+                    }).and_then(|(bean, _)| bean.reserve())
                     .and_then(|(bean, response)| match response {
                         Ok(Response::Reserved(job)) => bean.bury(job.id, 10),
                         Ok(_) => panic!("Wrong response returned"),
                         Err(e) => panic!("Got error: {}", e),
-                    })
-                    .inspect(|(_, response)| match response {
+                    }).inspect(|(_, response)| match response {
                         Ok(v) => assert_eq!(*v, Response::Buried),
                         Err(e) => panic!("Got error: {}", e),
-                    })
-                    .and_then(|(bean, _)| {
+                    }).and_then(|(bean, _)| {
                         // how about another one?
                         bean.put(0, 1, 100, &b"more data"[..])
-                    })
-                    .inspect(|(_, response)| assert!(response.is_ok()))
+                    }).inspect(|(_, response)| assert!(response.is_ok()))
                     .and_then(|(bean, response)| match response {
                         Ok(Response::Inserted(id)) => bean.delete(id),
                         Ok(_) => panic!("Wrong response returned"),
                         Err(e) => panic!("Got error: {}", e),
-                    })
-                    .inspect(|(_, response)| match response {
+                    }).inspect(|(_, response)| match response {
                         Ok(v) => assert_eq!(*v, Response::Deleted),
                         Err(e) => {
                             // assert_eq!(*e, error::Consumer::NotFound);
                             panic!("Got error: {}", e)
                         }
-                    })
-                    .and_then(|(bean, _)| bean.watch("test"))
+                    }).and_then(|(bean, _)| bean.watch("test"))
                     .inspect(|(_, response)| match response {
                         Ok(v) => assert_eq!(*v, Response::Watching(2)),
                         Err(e) => panic!("Got error: {}", e),
-                    })
-                    .and_then(|(bean, _)| bean.ignore("test"))
+                    }).and_then(|(bean, _)| bean.ignore("test"))
                     .inspect(|(_, response)| match response {
                         Ok(v) => assert_eq!(*v, Response::Watching(1)),
                         Err(e) => panic!("Got error: {}", e),

--- a/src/proto/error.rs
+++ b/src/proto/error.rs
@@ -29,6 +29,11 @@ pub enum BeanstalkError {
 /// Errors which can be casued due to a PUT command
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Fail)]
 pub enum Put {
+    /// The server ran out of memory trying to grow the priority queue data structure.
+    /// The client should try another server or disconnect and try again later.
+    #[fail(display = "Server had to bury the request")]
+    Buried,
+
     /// The job body must be followed by a CR-LF pair, that is, "\r\n". These two bytes are not counted
     /// in the job size given by the client in the put command line.
     ///

--- a/src/proto/error.rs
+++ b/src/proto/error.rs
@@ -55,6 +55,6 @@ pub enum Consumer {
     #[fail(display = "Job got buried")]
     Buried,
     /// If the client attempts to ignore the only tube in its watch list.
-    #[fail(display="Tried to ignore the only tube being watched")]
-    NotIgnored
+    #[fail(display = "Tried to ignore the only tube being watched")]
+    NotIgnored,
 }

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -58,7 +58,7 @@ impl CommandCodec {
                 "INSERTED" => {
                     let id = FromStr::from_str(list[1])?;
                     Ok(Response::Inserted(id))
-                },
+                }
                 "WATCHING" => {
                     let count = FromStr::from_str(list[1])?;
                     Ok(Response::Watching(count))
@@ -161,7 +161,7 @@ impl Encoder for CommandCodec {
                     bail!("Tube name too long")
                 }
                 item.serialize(dst)
-            },
+            }
             _ => item.serialize(dst),
         }
         Ok(())

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -8,11 +8,11 @@ use std::str::FromStr;
 
 pub mod error;
 mod request;
-mod response;
+pub(crate) mod response;
 
 use self::error::BeanstalkError;
 pub(crate) use self::request::Request;
-pub use self::response::Response;
+pub use self::response::*;
 
 use self::response::{Job, PreJob};
 
@@ -31,7 +31,7 @@ impl CommandCodec {
         CommandCodec { outstart: 0 }
     }
 
-    fn parse_response(&self, list: Vec<&str>) -> Result<Response, failure::Error> {
+    fn parse_response(&self, list: Vec<&str>) -> Result<AnyResponse, failure::Error> {
         eprintln!("Parsing: {:?}", list);
         if list.len() == 1 {
             return match list[0] {
@@ -44,10 +44,10 @@ impl CommandCodec {
                 "DRAINING" => Err(failure::Error::from(error::Put::Draining)),
                 "NOT_FOUND" => Err(failure::Error::from(error::Consumer::NotFound)),
                 "NOT_IGNORED" => Err(failure::Error::from(error::Consumer::NotIgnored)),
-                "BURIED" => Ok(Response::Buried),
-                "TOUCHED" => Ok(Response::Touched),
-                "RELEASED" => Ok(Response::Released),
-                "DELETED" => Ok(Response::Deleted),
+                "BURIED" => Ok(AnyResponse::Buried),
+                "TOUCHED" => Ok(AnyResponse::Touched),
+                "RELEASED" => Ok(AnyResponse::Released),
+                "DELETED" => Ok(AnyResponse::Deleted),
                 _ => bail!("Unknown response from server"),
             };
         }
@@ -57,20 +57,20 @@ impl CommandCodec {
             return match list[0] {
                 "INSERTED" => {
                     let id = FromStr::from_str(list[1])?;
-                    Ok(Response::Inserted(id))
+                    Ok(AnyResponse::Inserted(id))
                 }
                 "WATCHING" => {
                     let count = FromStr::from_str(list[1])?;
-                    Ok(Response::Watching(count))
+                    Ok(AnyResponse::Watching(count))
                 }
-                "USING" => Ok(Response::Using(String::from(list[1]))),
+                "USING" => Ok(AnyResponse::Using(String::from(list[1]))),
                 _ => bail!("Unknown resonse from server"),
             };
         }
 
         if list.len() == 3 {
             return match list[0] {
-                "RESERVED" => Ok(Response::Pre(parse_pre_job(list[1..].to_vec())?)),
+                "RESERVED" => Ok(AnyResponse::Pre(parse_pre_job(list[1..].to_vec())?)),
                 _ => bail!("Unknown response from server."),
             };
         }
@@ -106,7 +106,7 @@ fn parse_pre_job(list: Vec<&str>) -> Result<PreJob, failure::Error> {
 }
 
 impl Decoder for CommandCodec {
-    type Item = Response;
+    type Item = AnyResponse;
     type Error = failure::Error;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
@@ -126,11 +126,11 @@ impl Decoder for CommandCodec {
                 // Since the actual job data is on a second line, we need additional parsing
                 // extract it from the buffer.
                 match response {
-                    Response::Pre(pre) => {
+                    AnyResponse::Pre(pre) => {
                         if let Some(job) = self.parse_job(src, pre)? {
                             self.outstart = 0;
                             src.clear();
-                            return Ok(Some(Response::Reserved(job)));
+                            return Ok(Some(AnyResponse::Reserved(job)));
                         } else {
                             return Ok(None);
                         }

--- a/src/proto/request.rs
+++ b/src/proto/request.rs
@@ -42,8 +42,8 @@ pub(crate) enum Request {
 }
 
 impl Request {
-    /// The serailize method is used to serialize any request containig data. 
-    /// Since the beanstalkd protocol consists af ASCII characters, the 
+    /// The serailize method is used to serialize any request containig data.
+    /// Since the beanstalkd protocol consists af ASCII characters, the
     /// actual heavy lifting is done by the `Display` implementation.
     pub(crate) fn serialize(&self, dst: &mut BytesMut) {
         let format_string = format!("{}", &self);

--- a/src/proto/response.rs
+++ b/src/proto/response.rs
@@ -1,5 +1,4 @@
 //! Response types returned by Beanstalkd
-use std::fmt::{self, Display};
 
 /// This is an internal type which is not returned by tokio-beanstalkd.
 /// It is used when parsing the job data returned by Beanstald.
@@ -17,10 +16,17 @@ pub struct Job {
     pub data: Vec<u8>,
 }
 
-/// The response from Beanstalkd
+/// A response to an IGNORE command.
 #[derive(Debug, PartialEq, Eq)]
-pub enum Response {
-    OK,
+pub enum IgnoreResponse {
+    /// The integer number of tubes currently left in the watch list.
+    Watching(u32),
+    /// The client attempted to ignore the only tube in its watch list.
+    NotIgnored,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum AnyResponse {
     Reserved(Job),
     Inserted(super::Id),
     Buried,
@@ -35,10 +41,4 @@ pub enum Response {
     ConnectionClosed,
     // Custom type used for reserved job response parsing.
     Pre(PreJob),
-}
-
-impl Display for Response {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(self, f)
-    }
 }


### PR DESCRIPTION
Previously, all methods returned a generic `Response`. However, only certain variants are possible responses to each command. This forces users to manually match on the returned types, even when that shouldn't be necessary. This patch does the matching _inside_ the library, so that only the expected return value is exposed. If an incorrect variant (according to the protocol) is returned, an error is returned instead.