### PR TITLE
Update public API with better error types.

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -28,7 +28,7 @@ pub enum BeanstalkError {
 
     #[doc(hidden)]
     #[fail(display = "Just an extention..")]
-    __Nonexhaustive
+    __Nonexhaustive,
 }
 
 /// Errors which can be casued due to a PUT command
@@ -60,9 +60,10 @@ pub enum Put {
 
     #[doc(hidden)]
     #[fail(display = "Just an extention..")]
-    __Nonexhaustive
+    __Nonexhaustive,
 }
 
+/// Errors which can occur when acting as a consumer/worker
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Fail)]
 pub enum Consumer {
     /// If the job does not exist or is not either reserved by the client
@@ -80,5 +81,5 @@ pub enum Consumer {
 
     #[doc(hidden)]
     #[fail(display = "Just an extention..")]
-    __Nonexhaustive
+    __Nonexhaustive,
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,6 +25,10 @@ pub enum BeanstalkError {
 
     #[fail(display = "An unexpected response occurred")]
     UnexpectedResponse,
+
+    #[doc(hidden)]
+    #[fail(display = "Just an extention..")]
+    __Nonexhaustive
 }
 
 /// Errors which can be casued due to a PUT command
@@ -53,6 +57,10 @@ pub enum Put {
 
     #[fail(display = "A protocol error occurred: {}", error)]
     Beanstalk { error: BeanstalkError },
+
+    #[doc(hidden)]
+    #[fail(display = "Just an extention..")]
+    __Nonexhaustive
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Fail)]
@@ -69,4 +77,8 @@ pub enum Consumer {
 
     #[fail(display = "A protocol error occurred: {}", error)]
     Beanstalk { error: BeanstalkError },
+
+    #[doc(hidden)]
+    #[fail(display = "Just an extention..")]
+    __Nonexhaustive
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -22,6 +22,9 @@ pub enum BeanstalkError {
     /// This should not happen, if it does please file an issue.
     #[fail(display = "Unknown command sent by client")]
     UnknownCommand,
+
+    #[fail(display = "An unexpected response occurred")]
+    UnexpectedResponse
 }
 
 /// Errors which can be casued due to a PUT command
@@ -48,8 +51,10 @@ pub enum Put {
     #[fail(display = "Server is in drain mode")]
     Draining,
 
-    #[fail(display = "")]
-    Beanstalk(BeanstalkError)
+    #[fail(display = "A protocol error occurred: {}", error)]
+    Beanstalk {
+        error: BeanstalkError
+    }
 
 }
 
@@ -64,4 +69,9 @@ pub enum Consumer {
     /// If the client attempts to ignore the only tube in its watch list.
     #[fail(display = "Tried to ignore the only tube being watched")]
     NotIgnored,
+    
+    #[fail(display = "A protocol error occurred: {}", error)]
+    Beanstalk {
+        error: BeanstalkError
+    }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,5 @@
+//! The errors returned by the different operations in the library
+
 /// Errors that can be returned for any command
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Fail)]
 pub enum BeanstalkError {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,67 @@
+/// Errors that can be returned for any command
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Fail)]
+pub enum BeanstalkError {
+    /// The client sent a command line that was not well-formed. This can happen if the line does not
+    /// end with \r\n, if non-numeric characters occur where an integer is expected, if the wrong
+    /// number of arguments are present, or if the command line is mal-formed in any other way.
+    ///
+    /// This should not happen, if it does please file an issue.
+    #[fail(display = "Client command was not well formatted")]
+    BadFormat,
+
+    /// The server cannot allocate enough memory for the job. The client should try again later.
+    #[fail(display = "Server out of memory")]
+    OutOfMemory,
+
+    /// This indicates a bug in the server. It should never happen. If it does happen, please report it
+    /// at http://groups.google.com/group/beanstalk-talk.
+    #[fail(display = "Internal server error")]
+    InternalError,
+    /// The client sent a command that the server does not know.
+    ///
+    /// This should not happen, if it does please file an issue.
+    #[fail(display = "Unknown command sent by client")]
+    UnknownCommand,
+}
+
+/// Errors which can be casued due to a PUT command
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Fail)]
+pub enum Put {
+    /// The server ran out of memory trying to grow the priority queue data structure.
+    /// The client should try another server or disconnect and try again later.
+    #[fail(display = "Server had to bury the request")]
+    Buried,
+
+    /// The job body must be followed by a CR-LF pair, that is, "\r\n". These two bytes are not counted
+    /// in the job size given by the client in the put command line.
+    ///
+    /// This should never happen, if it does please file an issue.
+    #[fail(display = "CRLF missing from the end of command")]
+    ExpectedCRLF,
+
+    /// The client has requested to put a job with a body larger than max-job-size bytes
+    #[fail(display = "Job size exceeds max-job-size bytes")]
+    JobTooBig,
+
+    /// This means that the server has been put into "drain mode" and is no longer accepting new jobs.
+    /// The client should try another server or disconnect and try again later.
+    #[fail(display = "Server is in drain mode")]
+    Draining,
+
+    #[fail(display = "")]
+    Beanstalk(BeanstalkError)
+
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Fail)]
+pub enum Consumer {
+    /// If the job does not exist or is not either reserved by the client
+    #[fail(display = "Did not find a job of that Id")]
+    NotFound,
+    /// if the server ran out of memory trying to grow the priority queue data structure.
+    #[fail(display = "Job got buried")]
+    Buried,
+    /// If the client attempts to ignore the only tube in its watch list.
+    #[fail(display = "Tried to ignore the only tube being watched")]
+    NotIgnored,
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -24,7 +24,7 @@ pub enum BeanstalkError {
     UnknownCommand,
 
     #[fail(display = "An unexpected response occurred")]
-    UnexpectedResponse
+    UnexpectedResponse,
 }
 
 /// Errors which can be casued due to a PUT command
@@ -52,10 +52,7 @@ pub enum Put {
     Draining,
 
     #[fail(display = "A protocol error occurred: {}", error)]
-    Beanstalk {
-        error: BeanstalkError
-    }
-
+    Beanstalk { error: BeanstalkError },
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Fail)]
@@ -69,9 +66,7 @@ pub enum Consumer {
     /// If the client attempts to ignore the only tube in its watch list.
     #[fail(display = "Tried to ignore the only tube being watched")]
     NotIgnored,
-    
+
     #[fail(display = "A protocol error occurred: {}", error)]
-    Beanstalk {
-        error: BeanstalkError
-    }
+    Beanstalk { error: BeanstalkError },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ extern crate futures;
 extern crate failure;
 extern crate tokio;
 
-mod errors;
+pub mod errors;
 mod proto;
 
 use tokio::codec::Framed;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@
 //! rt.shutdown_on_idle();
 //! # }
 //! ```
-//! 
+//!
 //! And a worker could look something like this:
 //! ```no_run
 //! # extern crate tokio;
@@ -477,20 +477,22 @@ mod tests {
         }
         let mut rt = tokio::runtime::Runtime::new().unwrap();
         let bean = rt.block_on(
-            Beanstalkd::connect(&"127.0.0.1:11300".parse().expect("Unable to connect to Beanstalkd")).and_then(|bean| {
+            Beanstalkd::connect(
+                &"127.0.0.1:11300"
+                    .parse()
+                    .expect("Unable to connect to Beanstalkd"),
+            ).and_then(|bean| {
                 // Let put a job in
                 bean.put(0, 1, 100, &b"data"[..])
                     .inspect(|(_, response)| assert!(response.is_ok()))
                     .and_then(|(bean, _)| {
                         // how about another one?
                         bean.put(0, 1, 100, &b"more data"[..])
-                    })
-                    .inspect(|(_, response)| assert!(response.is_ok()))
+                    }).inspect(|(_, response)| assert!(response.is_ok()))
                     .and_then(|(bean, _)| {
                         // Let's watch a particular tube
                         bean.using("test")
-                    })
-                    .inspect(|(_, response)| assert_eq!(response.as_ref().unwrap(), "test"))
+                    }).inspect(|(_, response)| assert_eq!(response.as_ref().unwrap(), "test"))
             }),
         );
         assert!(!bean.is_err());
@@ -505,41 +507,37 @@ mod tests {
         }
         let mut rt = tokio::runtime::Runtime::new().unwrap();
         let bean = rt.block_on(
-            Beanstalkd::connect(&"127.0.0.1:11300".parse().expect("Unable to connect to Beanstalkd")).and_then(|bean| {
+            Beanstalkd::connect(
+                &"127.0.0.1:11300"
+                    .parse()
+                    .expect("Unable to connect to Beanstalkd"),
+            ).and_then(|bean| {
                 bean.put(0, 1, 100, &b"data"[..])
                     .inspect(|(_, response)| {
                         response.as_ref().unwrap();
-                    })
-                    .and_then(|(bean, _)| bean.reserve())
+                    }).and_then(|(bean, _)| bean.reserve())
                     .inspect(|(_, response)| assert_eq!(response.as_ref().unwrap().data, b"data"))
                     .and_then(|(bean, response)| bean.touch(response.unwrap().id))
                     .inspect(|(_, response)| {
                         response.as_ref().unwrap();
-                    })
-                    .and_then(|(bean, _)| {
+                    }).and_then(|(bean, _)| {
                         // how about another one?
                         bean.put(0, 1, 100, &b"more data"[..])
-                    })
-                    .and_then(|(bean, _)| bean.reserve())
+                    }).and_then(|(bean, _)| bean.reserve())
                     .and_then(|(bean, response)| bean.release(response.unwrap().id, 10, 10))
                     .inspect(|(_, response)| {
                         response.as_ref().unwrap();
-                    })
-                    .and_then(|(bean, _)| bean.reserve())
+                    }).and_then(|(bean, _)| bean.reserve())
                     .and_then(|(bean, response)| bean.bury(response.unwrap().id, 10))
                     .inspect(|(_, response)| {
                         response.as_ref().unwrap();
-                    })
-                    .and_then(|(bean, response)| bean.delete(100))
+                    }).and_then(|(bean, response)| bean.delete(100))
                     .inspect(|(_, response)| {
                         assert_eq!(*response, Err(errors::Consumer::NotFound));
-                    })
-                    .and_then(|(bean, _)| bean.watch("test"))
+                    }).and_then(|(bean, _)| bean.watch("test"))
                     .inspect(|(_, response)| assert_eq!(*response.as_ref().unwrap(), 2))
                     .and_then(|(bean, _)| bean.ignore("test"))
-                    .inspect(|(_, response)| {
-                        assert_eq!(*response.as_ref().unwrap(), 1)
-                    })
+                    .inspect(|(_, response)| assert_eq!(*response.as_ref().unwrap(), 1))
             }),
         );
         assert!(!bean.is_err());

--- a/src/proto/error.rs
+++ b/src/proto/error.rs
@@ -4,11 +4,14 @@ use std::fmt;
 use std::fmt::Display;
 use std::io;
 
+/// Custom error type which represents all the various errors which can occur
+/// when decoding a response from the server
 #[derive(Debug)]
 pub(crate) struct Decode {
     inner: Context<ErrorKind>,
 }
 
+/// Enum that helps understand what kind of a decoder error occurred.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Fail)]
 pub(crate) enum ErrorKind {
     #[fail(display = "A protocol error occurred")]
@@ -19,11 +22,20 @@ pub(crate) enum ErrorKind {
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub(crate) enum ParsingError {
+    /// Represents errors when parsing an Integer value such as a Job ID or the
+    /// number of tubes being watched
     ParseId,
+
+    /// Represents any errors which occur when converting the parsed ASCII string
+    /// to UTF8. This should not occur as the Beanstalkd protocol only works with
+    /// ASCII names
     ParseString,
+
+    /// If some unknown error occurred.
     UnknownResponse,
 }
 
+/// This helps us keep track of the underlying cause of the error
 impl Fail for Decode {
     fn cause(&self) -> Option<&Fail> {
         self.inner.cause()

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -18,11 +18,11 @@ use self::error::{Decode, ErrorKind, ParsingError, ProtocolError};
 use self::response::{Job, PreJob};
 
 /// A Tube is a way of separating different types of jobs in Beanstalkd.
-/// 
-///  The clinet can use a particular tube by calling [`using`][using] and Beanstalkd will create a 
-/// new tube if one does not already exist with that name. Workers can [`watch`][watch] particular 
+///
+///  The clinet can use a particular tube by calling [`using`][using] and Beanstalkd will create a
+/// new tube if one does not already exist with that name. Workers can [`watch`][watch] particular
 /// tubes and receive jobs only from those tubes.
-/// 
+///
 /// [using]: struct.Beanstalkd.html#method.using
 /// [watch]: struct.Beanstalkd.html#method.watch
 pub type Tube = String;
@@ -66,13 +66,13 @@ impl CommandCodec {
             eprintln!("Parsing: {:?}", list[1]);
             return match list[0] {
                 "INSERTED" => {
-                    let id: u32 =
-                        u32::from_str(list[1]).context(ErrorKind::Parsing(ParsingError::ParseId))?;
+                    let id: u32 = u32::from_str(list[1])
+                        .context(ErrorKind::Parsing(ParsingError::ParseId))?;
                     Ok(AnyResponse::Inserted(id))
                 }
                 "WATCHING" => {
-                    let count =
-                        u32::from_str(list[1]).context(ErrorKind::Parsing(ParsingError::ParseId))?;
+                    let count = u32::from_str(list[1])
+                        .context(ErrorKind::Parsing(ParsingError::ParseId))?;
                     Ok(AnyResponse::Watching(count))
                 }
                 "USING" => Ok(AnyResponse::Using(String::from(list[1]))),

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -17,8 +17,17 @@ pub use self::response::*;
 use self::error::{Decode, ErrorKind, ParsingError, ProtocolError};
 use self::response::{Job, PreJob};
 
+/// A Tube is a way of separating different types of jobs in Beanstalkd.
+/// 
+///  The clinet can use a particular tube by calling [`using`][using] and Beanstalkd will create a 
+/// new tube if one does not already exist with that name. Workers can [`watch`][watch] particular 
+/// tubes and receive jobs only from those tubes.
+/// 
+/// [using]: struct.Beanstalkd.html#method.using
+/// [watch]: struct.Beanstalkd.html#method.watch
 pub type Tube = String;
 
+/// The ID of a job assigned by Beanstalkd
 pub type Id = u32;
 
 #[derive(Debug, Clone)]

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -31,7 +31,7 @@ impl CommandCodec {
         CommandCodec { outstart: 0 }
     }
 
-    fn parse_response(&self, list: Vec<&str>) -> Result<AnyResponse, error::DecoderError> {
+    fn parse_response(&self, list: Vec<&str>) -> Result<AnyResponse, error::Decode> {
         eprintln!("Parsing: {:?}", list);
         if list.len() == 1 {
             return match list[0] {
@@ -96,11 +96,7 @@ impl CommandCodec {
         ))?
     }
 
-    fn parse_job(
-        &mut self,
-        src: &mut BytesMut,
-        pre: PreJob,
-    ) -> Result<Option<Job>, error::DecoderError> {
+    fn parse_job(&mut self, src: &mut BytesMut, pre: PreJob) -> Result<Option<Job>, error::Decode> {
         if let Some(carriage_offset) = src.iter().position(|b| *b == b'\r') {
             if src[carriage_offset + 1] == b'\n' {
                 let line =
@@ -118,7 +114,7 @@ impl CommandCodec {
     }
 }
 
-fn parse_pre_job(list: Vec<&str>) -> Result<PreJob, error::DecoderError> {
+fn parse_pre_job(list: Vec<&str>) -> Result<PreJob, error::Decode> {
     let id =
         u32::from_str(list[0]).context(error::ErrorKind::Parsing(error::ParsingError::ParseId))?;
     let bytes =
@@ -128,7 +124,7 @@ fn parse_pre_job(list: Vec<&str>) -> Result<PreJob, error::DecoderError> {
 
 impl Decoder for CommandCodec {
     type Item = AnyResponse;
-    type Error = error::DecoderError;
+    type Error = error::Decode;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         eprintln!("Decoding: {:?}", src);

--- a/src/proto/response.rs
+++ b/src/proto/response.rs
@@ -16,15 +16,6 @@ pub struct Job {
     pub data: Vec<u8>,
 }
 
-/// A response to an IGNORE command.
-#[derive(Debug, PartialEq, Eq)]
-pub enum IgnoreResponse {
-    /// The integer number of tubes currently left in the watch list.
-    Watching(u32),
-    /// The client attempted to ignore the only tube in its watch list.
-    NotIgnored,
-}
-
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum AnyResponse {
     Reserved(Job),

--- a/src/proto/response.rs
+++ b/src/proto/response.rs
@@ -11,11 +11,17 @@ pub struct PreJob {
 /// A job according to Beanstalkd
 #[derive(Debug, PartialEq, Eq)]
 pub struct Job {
+    /// The ID job assigned by Beanstalkd
     pub id: super::Id,
+
+    /// The size of the payload
     pub bytes: usize,
+
+    /// The payload
     pub data: Vec<u8>,
 }
 
+/// All possible responses that the Beanstalkd server can send.
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum AnyResponse {
     Reserved(Job),


### PR DESCRIPTION
Previously, all public methods were returning a 

```rust 
Result<(Beanstalkd, Result<_, failure::Error>), failure::Error>
```

This meant that any error which was returned by the method had to be downcast in order to get at the underlying error.

This is not really ideas as we would like the users to know why a particular operation failed. This PR updates all public APIs and adds a new internal error type which only occurs during the decoding step (`Decode`) which is then matched on to return method specific error types from the methods. 

The public error types are also non-exhaustive enums so that we can ensure forward compatibility if new variants were to be added.