### PR TITLE
Fix some issues pointed out by clippy.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ use std::net::SocketAddr;
 use proto::error as proto_error;
 pub use proto::response::*;
 pub use proto::{Id, Tube};
-use proto_error::{ErrorKind, ParsingError, ProtocolError};
+use proto_error::{ErrorKind, ProtocolError};
 // Request doesn't have to be a public type
 use proto::Request;
 
@@ -143,7 +143,7 @@ impl Beanstalkd {
     pub fn connect(addr: &SocketAddr) -> impl Future<Item = Self, Error = failure::Error> {
         tokio::net::TcpStream::connect(addr)
             .map_err(failure::Error::from)
-            .map(|stream| Beanstalkd::setup(stream))
+            .map(Beanstalkd::setup)
     }
 
     fn setup(stream: tokio::net::TcpStream) -> Self {

--- a/src/proto/error.rs
+++ b/src/proto/error.rs
@@ -68,7 +68,7 @@ impl From<ErrorKind> for Decode {
 
 // Why do I have to implement this?
 impl From<io::Error> for Decode {
-    fn from(kind: io::Error) -> Decode {
+    fn from(_kind: io::Error) -> Decode {
         Decode {
             inner: Context::new(ErrorKind::Parsing(ParsingError::ParseString)),
         }

--- a/src/proto/response.rs
+++ b/src/proto/response.rs
@@ -2,7 +2,7 @@
 
 /// This is an internal type which is not returned by tokio-beanstalkd.
 /// It is used when parsing the job data returned by Beanstald.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct PreJob {
     pub id: super::Id,
     pub bytes: usize,


### PR DESCRIPTION
You can run clippy on stable now! Running it on this crate surprisingly resulted a not a lot of issues.

Need to disable the suggestion of using `writeln!()` instead of `write!()` as the `\r\n` at the end of each message is a part of the protocol and I want it to be explicit.