### PR TITLE
Adding peek commands

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,17 +12,13 @@
 //!
 //! ## Operation
 //! This library can serve as a client for both the application and the worker. The application would
-//! [`put`][put] jobs on the queue and the workers can [`reserve`][reserve] them. Once they are done with the job, they
-//! have to [`delete`][delete] job. This is required for every job, or else Beanstalkd will not remove it from
-//! its internal datastructres.
+//! [`put`](tokio_beanstalkd::put) jobs on the queue and the workers can [`reserve`](tokio_beanstalkd::put)
+//! them. Once they are done with the job, they have to [`delete`](tokio_beanstalkd::delete) job.
+//! This is required for every job, or else Beanstalkd will not remove it fromits internal datastructres.
 //!
-//! [put]: struct.Beanstalkd.html#method.put
-//! [reserve]: struct.Beanstalkd.html#method.reserve
-//! [delete]: struct.Beanstalkd.html#method.delete
-//!
-//! If a worker cannot finish the job in it's TTR (Time To Run), then it can [`release`](release) the job. The
-//! application can use the [`using`](using) method to put jobs in a specific tube, and workers can use `watch`
-//! to only reserve jobs from the specified tubes.
+//! If a worker cannot finish the job in it's TTR (Time To Run), then it can [`release`](tokio_beanstalkd::release)
+//! the job. Theapplication can use the [`using`](tokio_beanstalkd::using) method to put jobs in a specific tube,
+//! and workers can use [watch](tokio_beanstalkd::watch)
 //!
 //! [release]: struct.Beanstalkd.html#method.release
 //! [using]: struct.Beanstalkd.html#method.using
@@ -214,12 +210,12 @@ impl Beanstalkd {
             })
     }
 
-    /// Reserve a [job](struct.Job.html) to process.
+    /// Reserve a [job](tokio_beanstalkd::response::Job) to process.
     ///
     /// A process that wants to consume jobs from the queue uses `reserve`,
-    /// [delete](struct.Beanstalkd.html#method.delete),
-    /// [release](struct.Beanstalkd.html#method.release), and
-    /// [bury](struct.Beanstalkd.html#method.bury).
+    /// `[delete](tokio_beanstalkd::delete)`,
+    /// `[release](tokio_beanstalkd::release)`, and
+    /// `[bury](tokio_beanstalkd::bury)`.
     pub fn reserve(
         self,
     ) -> impl Future<Item = (Self, Result<Job, Consumer>), Error = failure::Error> {
@@ -452,10 +448,9 @@ impl Beanstalkd {
             })
     }
 
-    /// The peek command let the client inspect a job in the system. There are four
-    /// variations ([PeekType][tokio_beanstalkd::PeekType]). All but the first operate only on the currently used tube.
-    ///
-    /// This lets you get the information regarding the given type of a job
+    /// The peek command lets the client inspect a job in the system. There are four
+    /// types of jobs as enumerated in [PeekType](tokio_beanstalkd::PeekType). All but the
+    /// first operate only on the currently used tube.
     pub fn peek(
         self,
         peek_type: PeekType,

--- a/src/proto/error.rs
+++ b/src/proto/error.rs
@@ -31,6 +31,9 @@ pub(crate) enum ParsingError {
     /// ASCII names
     ParseString,
 
+    /// Error occurred while parsing the data for a Job
+    ParseJob,
+
     /// If some unknown error occurred.
     UnknownResponse,
 }

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -98,7 +98,7 @@ impl CommandCodec {
                 )?)),
                 "FOUND" => Ok(AnyResponse::Pre(parse_pre_job(
                     &list[1..],
-                    response::PreResponse::Peek
+                    response::PreResponse::Peek,
                 )?)),
                 _ => Err(ErrorKind::Parsing(ParsingError::UnknownResponse))?,
             };

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -96,6 +96,10 @@ impl CommandCodec {
                     &list[1..],
                     response::PreResponse::Reserved,
                 )?)),
+                "FOUND" => Ok(AnyResponse::Pre(parse_pre_job(
+                    &list[1..],
+                    response::PreResponse::Peek
+                )?)),
                 _ => Err(ErrorKind::Parsing(ParsingError::UnknownResponse))?,
             };
         }

--- a/src/proto/request.rs
+++ b/src/proto/request.rs
@@ -105,7 +105,7 @@ impl fmt::Display for Request {
             Request::Ignore { tube } => write!(f, "ignore {}\r\n", tube),
             Request::Peek { id } => write!(f, "peek {}\r\n", id),
             Request::PeekReady => write!(f, "peek-ready\r\n"),
-            Request::PeekDelay => write!(f, "peek-delay\r\n"),
+            Request::PeekDelay => write!(f, "peek-delayed\r\n"),
             Request::PeekBuried => write!(f, "peek-buried\r\n"),
         }
     }

--- a/src/proto/request.rs
+++ b/src/proto/request.rs
@@ -39,6 +39,9 @@ pub(crate) enum Request {
     Peek {
         id: super::Id,
     },
+    PeekReady,
+    PeekDelay,
+    PeekBuried,
 }
 
 impl Request {
@@ -57,6 +60,9 @@ impl Request {
                 dst.put(&b"\r\n"[..]);
             }
             Request::Reserve
+            | Request::PeekReady
+            | Request::PeekDelay
+            | Request::PeekBuried
             | Request::Use { .. }
             | Request::Delete { .. }
             | Request::Release { .. }
@@ -98,6 +104,9 @@ impl fmt::Display for Request {
             Request::Watch { tube } => write!(f, "watch {}\r\n", tube),
             Request::Ignore { tube } => write!(f, "ignore {}\r\n", tube),
             Request::Peek { id } => write!(f, "peek {}\r\n", id),
+            Request::PeekReady => write!(f, "peek-ready\r\n"),
+            Request::PeekDelay => write!(f, "peek-delay\r\n"),
+            Request::PeekBuried => write!(f, "peek-buried\r\n"),
         }
     }
 }

--- a/src/proto/response.rs
+++ b/src/proto/response.rs
@@ -32,6 +32,10 @@ pub struct Job {
     pub data: Vec<u8>,
 }
 
+pub struct Stats {
+
+}
+
 impl PreJob {
     /// Simple method to match a given PreJob to the right Response
     pub(crate) fn to_anyresponse(self, job: Job) -> AnyResponse {

--- a/src/proto/response.rs
+++ b/src/proto/response.rs
@@ -3,11 +3,11 @@
 /// [pre]: [tokio_beanstalkd::proto::response::PreJob]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum PreResponse {
+    /// A response for a reserve request
     Reserved,
+
+    /// All types of peek requests have the same response
     Peek,
-    PeekReady,
-    PeekDelayed,
-    PeekBuried,
 }
 
 /// This is an internal type which is not returned by tokio-beanstalkd.
@@ -37,8 +37,7 @@ impl PreJob {
     pub(crate) fn to_anyresponse(self, job: Job) -> AnyResponse {
         match self.response_type {
             PreResponse::Reserved => AnyResponse::Reserved(job),
-            // FIXME: handle all other response types.
-            _ => AnyResponse::Reserved(job)
+            PreResponse::Peek => AnyResponse::Found(job),
         }
     }
 }

--- a/src/proto/response.rs
+++ b/src/proto/response.rs
@@ -1,11 +1,22 @@
 //! Response types returned by Beanstalkd
 
+/// [pre]: [tokio_beanstalkd::proto::response::PreJob]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum PreResponse {
+    Reserved,
+    Peek,
+    PeekReady,
+    PeekDelayed,
+    PeekBuried,
+}
+
 /// This is an internal type which is not returned by tokio-beanstalkd.
 /// It is used when parsing the job data returned by Beanstald.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct PreJob {
     pub id: super::Id,
     pub bytes: usize,
+    pub response_type: PreResponse,
 }
 
 /// A job according to Beanstalkd
@@ -19,6 +30,17 @@ pub struct Job {
 
     /// The payload
     pub data: Vec<u8>,
+}
+
+impl PreJob {
+    /// Simple method to match a given PreJob to the right Response
+    pub(crate) fn to_anyresponse(self, job: Job) -> AnyResponse {
+        match self.response_type {
+            PreResponse::Reserved => AnyResponse::Reserved(job),
+            // FIXME: handle all other response types.
+            _ => AnyResponse::Reserved(job)
+        }
+    }
 }
 
 /// All possible responses that the Beanstalkd server can send.


### PR DESCRIPTION
Add a method `peek` which can handle all the different variants of peek requests handled by beanstalkd.