### PR TITLE
 Return Response object from public API. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tokio-beanstalkd"
 version = "0.5.0-alpha.1"
 authors = ["Bhargav Voleti <bhargav.voleti93@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 description = "Asynchronous client library for interacting with Beanstalkd work queue."
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,14 @@ categories = ["api-bindings", "asynchronous", "network-programming"]
 license = "MIT"
 
 [dependencies]
-tokio = { version = "1", features = ["net"] }
+tokio = { version = "~1", features = ["net"] }
 tokio-util = { version = "0.7.10", features = ["codec"] }
 tokio-stream = "0.1.14"
 futures = "0.3.29"
 thiserror = "1.0.50"
+tracing = "0.1.40"
 
 [dev-dependencies]
-tokio = { version = "1", features = ["net", "rt", "macros"] }
+pretty_assertions = "1.4.0"
+tokio = { version = "1", features = ["full", "tracing"] }
+tracing-test = { version = "0.2.4", features = ["no-env-filter"] }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,1 @@
-edition = "2018"
+edition = "2021"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,6 +5,7 @@ use crate::proto::error::{Decode, EncodeError, ProtocolError};
 
 /// Errors that can be returned for any command
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Error)]
+#[non_exhaustive]
 pub enum BeanstalkError {
     /// The client sent a command line that was not well-formed. This can happen if the line does not
     /// end with \r\n, if non-numeric characters occur where an integer is expected, if the wrong
@@ -36,10 +37,6 @@ pub enum BeanstalkError {
 
     #[error("IO Error")]
     IoError,
-
-    #[doc(hidden)]
-    #[error("Just an extention..")]
-    __Nonexhaustive,
 }
 
 impl From<Decode> for BeanstalkError {
@@ -65,6 +62,7 @@ impl From<EncodeError> for BeanstalkError {
 
 /// Errors which can be casued due to a PUT command
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Error)]
+#[non_exhaustive]
 pub enum Put {
     /// The server ran out of memory trying to grow the priority queue data structure.
     /// The client should try another server or disconnect and try again later.
@@ -89,10 +87,6 @@ pub enum Put {
 
     #[error("A protocol error occurred: {}", error)]
     Beanstalk { error: BeanstalkError },
-
-    #[doc(hidden)]
-    #[error("Just an extention..")]
-    __Nonexhaustive,
 }
 
 impl From<Decode> for Put {
@@ -118,6 +112,7 @@ impl From<EncodeError> for Put {
 
 /// Errors which can occur when acting as a consumer/worker
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Error)]
+#[non_exhaustive]
 pub enum Consumer {
     /// If the job does not exist or is not either reserved by the client
     #[error("Did not find a job of that Id")]
@@ -131,10 +126,6 @@ pub enum Consumer {
 
     #[error("A protocol error occurred: {}", error)]
     Beanstalk { error: BeanstalkError },
-
-    #[doc(hidden)]
-    #[error("Just an extention..")]
-    __Nonexhaustive,
 }
 
 impl From<Decode> for Consumer {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,7 @@
 //! The errors returned by the different operations in the library
 use thiserror::Error;
 
-use crate::proto::error::{Decode, EncodeError, ProtocolError};
+use crate::proto::error::{BeanError, EncodeError, ProtocolError};
 
 /// Errors that can be returned for any command
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Error)]
@@ -39,13 +39,13 @@ pub enum BeanstalkError {
     IoError,
 }
 
-impl From<Decode> for BeanstalkError {
-    fn from(error: Decode) -> Self {
+impl From<BeanError> for BeanstalkError {
+    fn from(error: BeanError) -> Self {
         match error {
-            Decode::Protocol(ProtocolError::BadFormat) => BeanstalkError::BadFormat,
-            Decode::Protocol(ProtocolError::OutOfMemory) => BeanstalkError::OutOfMemory,
-            Decode::Protocol(ProtocolError::InternalError) => BeanstalkError::InternalError,
-            Decode::Protocol(ProtocolError::UnknownCommand) => BeanstalkError::UnknownCommand,
+            BeanError::Protocol(ProtocolError::BadFormat) => BeanstalkError::BadFormat,
+            BeanError::Protocol(ProtocolError::OutOfMemory) => BeanstalkError::OutOfMemory,
+            BeanError::Protocol(ProtocolError::InternalError) => BeanstalkError::InternalError,
+            BeanError::Protocol(ProtocolError::UnknownCommand) => BeanstalkError::UnknownCommand,
             _ => BeanstalkError::UnexpectedResponse,
         }
     }
@@ -89,12 +89,12 @@ pub enum Put {
     Beanstalk { error: BeanstalkError },
 }
 
-impl From<Decode> for Put {
-    fn from(error: Decode) -> Self {
+impl From<BeanError> for Put {
+    fn from(error: BeanError) -> Self {
         match error {
-            Decode::Protocol(ProtocolError::ExpectedCRLF) => Put::ExpectedCRLF,
-            Decode::Protocol(ProtocolError::JobTooBig) => Put::JobTooBig,
-            Decode::Protocol(ProtocolError::Draining) => Put::Draining,
+            BeanError::Protocol(ProtocolError::ExpectedCRLF) => Put::ExpectedCRLF,
+            BeanError::Protocol(ProtocolError::JobTooBig) => Put::JobTooBig,
+            BeanError::Protocol(ProtocolError::Draining) => Put::Draining,
             _ => Put::Beanstalk {
                 error: error.into(),
             },
@@ -128,11 +128,10 @@ pub enum Consumer {
     Beanstalk { error: BeanstalkError },
 }
 
-impl From<Decode> for Consumer {
-    fn from(error: Decode) -> Self {
+impl From<BeanError> for Consumer {
+    fn from(error: BeanError) -> Self {
         match error {
-            Decode::Protocol(ProtocolError::NotFound) => Consumer::NotFound,
-            Decode::Protocol(ProtocolError::NotIgnored) => Consumer::NotIgnored,
+            BeanError::Protocol(ProtocolError::NotIgnored) => Consumer::NotIgnored,
             _ => Consumer::Beanstalk {
                 error: error.into(),
             },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ impl Beanstalkd {
 
         match self.connection.next().await {
             Some(r) => r,
-            None => Err(Decode::Protocol(ProtocolError::StreamClosed).into()),
+            None => Err(Decode::Protocol(ProtocolError::StreamClosed)),
         }
     }
 

--- a/src/proto/error.rs
+++ b/src/proto/error.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 
 /// Enum that helps understand what kind of a decoder error occurred.
 #[derive(Debug, Error)]
-pub(crate) enum Decode {
+pub(crate) enum BeanError {
     #[error("A protocol error occurred")]
     Protocol(#[from] ProtocolError),
     #[error("A parsing error occurred")]
@@ -54,8 +54,6 @@ pub(crate) enum ProtocolError {
     JobTooBig,
     #[error("Draining")]
     Draining,
-    #[error("NotFound")]
-    NotFound,
     #[error("NotIgnored")]
     NotIgnored,
     #[error("StreamClosed")]

--- a/src/proto/response.rs
+++ b/src/proto/response.rs
@@ -36,28 +36,48 @@ pub struct Stats {}
 
 impl PreJob {
     /// Simple method to match a given PreJob to the right Response
-    pub(crate) fn to_anyresponse(self, job: Job) -> AnyResponse {
+    pub(crate) fn to_anyresponse(self, job: Job) -> Response {
         match self.response_type {
-            PreResponse::Reserved => AnyResponse::Reserved(job),
-            PreResponse::Peek => AnyResponse::Found(job),
+            PreResponse::Reserved => Response::Reserved(job),
+            PreResponse::Peek => Response::Found(job),
         }
     }
 }
 
 /// All possible responses that the Beanstalkd server can send.
 #[derive(Debug, PartialEq, Eq)]
-pub(crate) enum AnyResponse {
+#[non_exhaustive]
+pub enum Response {
     Reserved(Job),
     Inserted(super::Id),
-    Buried,
+
+    /// Specifies buried state for different commands
+    ///
+    /// - Release: If the server ran out of memory trying to grow the priority queue data structure.
+    /// - Bury: to indicate success
+    /// -
+    Buried(Option<super::Id>),
+
+    /// Response from [`use`][super::Beanstalkd::use]
+    ///
+    /// - <tube> is the name of the tube now being used.
     Using(super::Tube),
+
+
     Deleted,
     Watching(u32),
+
+    /// To indicate success for the `release` command.
     Released,
+
     Touched,
     Found(Job),
     Kicked(u32),
     JobKicked,
+
+    /// If the job does not exist or is not reserved by the client
+    NotFound,
+
     // Custom type used for reserved job response parsing.
     Pre(PreJob),
 }


### PR DESCRIPTION
* The previous API returned specific success values on command successe and
  OK(()) in any other success case, even if the server returned a valid success
  response. This was incorrect behavior in many cases, including not returning
  the correct value for a few valid responses.
* Also fix a bug around stream closing. When the server returns `NOT_FOUND`, we
  treated it as an error and closed the stream, even though it is a valid
  response for various commands.