### PR TITLE
Fix delete command

### DIFF
--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -8,6 +8,7 @@ use tracing::trace;
 use std::io;
 use std::str;
 use std::str::FromStr;
+use std::fmt;
 
 pub(crate) mod error;
 mod request;
@@ -36,6 +37,12 @@ pub struct Id(u32);
 impl From<u32> for Id {
     fn from(value: u32) -> Self {
         Self(value)
+    }
+}
+
+impl fmt::Display for Id {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 

--- a/src/proto/request.rs
+++ b/src/proto/request.rs
@@ -102,7 +102,7 @@ impl fmt::Display for Request {
             ),
             Request::Reserve => write!(f, "reserve\r\n"),
             Request::Use { tube } => write!(f, "use {}\r\n", tube),
-            Request::Delete { id } => write!(f, "delete {:?}\r\n", id),
+            Request::Delete { id } => write!(f, "delete {}\r\n", id),
             Request::Release {
                 id,
                 priority,


### PR DESCRIPTION
This was error response when trying to use delete method:

    Client command was not well formatted

Looking at packet sniffer, noticed client was sending:

    delete Id(1)

Notice the extraneous `Id(1)`. Fixed by adding a custom display and now it properly sends which adheres to the beanstlakd protocol.

    delete 1

May need to fix the other commands that send job ID as well.